### PR TITLE
Multiply health consumables by mission duration to produce demand

### DIFF
--- a/src/main/java/edu/mit/spacenet/domain/model/CrewConsumablesDemandModel.java
+++ b/src/main/java/edu/mit/spacenet/domain/model/CrewConsumablesDemandModel.java
@@ -133,7 +133,8 @@ public class CrewConsumablesDemandModel extends AbstractDemandModel {
         getEvaLithiumHydroxide() * getMissionEvaCrewTime()));
     demands.add(new Demand(new GenericResource(ClassOfSupply.COS303), getHealthEquipment()));
     demands.add(new Demand(new GenericResource(ClassOfSupply.COS303),
-        getHealthConsumables() * getMissionCrewSize()));
+        (getMissionExplorationDuration() + getMissionTransitDuration()) * getHealthConsumables()
+            * getMissionCrewSize()));
     demands.add(new Demand(new GenericResource(ClassOfSupply.COS304), getSafetyEquipment()));
     demands.add(new Demand(new GenericResource(ClassOfSupply.COS305), getCommEquipment()));
     demands.add(new Demand(new GenericResource(ClassOfSupply.COS306),


### PR DESCRIPTION
Fixes inconsistency between SpaceNet 1.3 documentation and SpaceNet 2.5 implementation described in #59 